### PR TITLE
Add sample frontend and root route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 package-lock.json
 .env
 access.log
-public/

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,85 @@
+/* eslint-env browser */
+
+const addressForm = document.getElementById('address-form');
+const loadAddressesBtn = document.getElementById('load-addresses');
+const addressTable = document.getElementById('address-table');
+
+const institutionForm = document.getElementById('institution-form');
+const loadInstitutionsBtn = document.getElementById('load-institutions');
+const institutionTable = document.getElementById('institution-table');
+
+const clearTable = (table) => { while (table.firstChild) table.removeChild(table.firstChild); };
+
+addressForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const formData = new FormData(addressForm);
+  const data = Object.fromEntries(formData.entries());
+  await fetch('/address/persist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  addressForm.reset();
+});
+
+loadAddressesBtn.addEventListener('click', async () => {
+  const res = await fetch('/address');
+  const json = await res.json();
+  clearTable(addressTable);
+  if (json.data) {
+    const header = document.createElement('tr');
+    ['id', 'country', 'state', 'city', 'neighborhood', 'street', 'postalCode']
+      .forEach((field) => {
+        const th = document.createElement('th');
+        th.textContent = field;
+        header.appendChild(th);
+      });
+    addressTable.appendChild(header);
+    json.data.forEach((addr) => {
+      const row = document.createElement('tr');
+      header.childNodes.forEach((th) => {
+        const td = document.createElement('td');
+        td.textContent = addr[th.textContent];
+        row.appendChild(td);
+      });
+      addressTable.appendChild(row);
+    });
+  }
+});
+
+institutionForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const formData = new FormData(institutionForm);
+  const data = Object.fromEntries(formData.entries());
+  await fetch('/institution/persist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  institutionForm.reset();
+});
+
+loadInstitutionsBtn.addEventListener('click', async () => {
+  const res = await fetch('/institution');
+  const json = await res.json();
+  clearTable(institutionTable);
+  if (json.data) {
+    const header = document.createElement('tr');
+    ['id', 'name', 'document_number', 'address_id']
+      .forEach((field) => {
+        const th = document.createElement('th');
+        th.textContent = field;
+        header.appendChild(th);
+      });
+    institutionTable.appendChild(header);
+    json.data.forEach((inst) => {
+      const row = document.createElement('tr');
+      header.childNodes.forEach((th) => {
+        const td = document.createElement('td');
+        td.textContent = inst[th.textContent];
+        row.appendChild(td);
+      });
+      institutionTable.appendChild(row);
+    });
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+  <head>
+    <meta charset="UTF-8">
+    <title>ABEX API</title>
+    <script defer src="app.js"></script>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; }
+      form { margin-bottom: 2rem; }
+      label { display: block; margin-top: 0.5rem; }
+      input { padding: 0.4rem; width: 100%; max-width: 400px; }
+      button { margin-top: 1rem; padding: 0.5rem 1rem; }
+      table { border-collapse: collapse; margin-top: 1rem; }
+      th, td { border: 1px solid #ccc; padding: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>ABEX API - Frontend de Exemplo</h1>
+
+    <section>
+      <h2>Cadastro de Endereço</h2>
+      <form id="address-form">
+        <label>País
+          <input name="country" required>
+        </label>
+        <label>Estado
+          <input name="state" required>
+        </label>
+        <label>Cidade
+          <input name="city" required>
+        </label>
+        <label>Bairro
+          <input name="neighborhood" required>
+        </label>
+        <label>Rua
+          <input name="street" required>
+        </label>
+        <label>CEP
+          <input name="postalCode" required>
+        </label>
+        <button type="submit">Salvar Endereço</button>
+      </form>
+      <button id="load-addresses">Listar Endereços</button>
+      <table id="address-table"></table>
+    </section>
+
+    <section>
+      <h2>Cadastro de Instituição</h2>
+      <form id="institution-form">
+        <label>Nome
+          <input name="name" required>
+        </label>
+        <label>Documento
+          <input name="document_number" required>
+        </label>
+        <label>ID do Endereço
+          <input name="address_id" required>
+        </label>
+        <button type="submit">Salvar Instituição</button>
+      </form>
+      <button id="load-institutions">Listar Instituições</button>
+      <table id="institution-table"></table>
+    </section>
+  </body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -31,6 +31,10 @@ app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 app.use('/public', express.static('public'));
 
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public/index.html'));
+});
+
 routes(app);
 app.use((req, res) => {
   res.status(404).send('404 - Página não encontrada');


### PR DESCRIPTION
## Summary
- add simple HTML/JS interface for address and institution CRUD
- serve new interface through root route
- update gitignore to include public assets

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint public/app.js src/server.js`

------
https://chatgpt.com/codex/tasks/task_e_689650d1b7488325906164fc916f93f8