### PR TITLE
Add basic HTML registration forms for Address and Institution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 package-lock.json
 .env
 access.log
-public/
+public/uploads/

--- a/public/address.html
+++ b/public/address.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cadastro de Endereço</title>
+</head>
+<body>
+  <h1>Cadastro de Endereço</h1>
+  <form id="addressForm">
+    <label>País: <input type="text" name="country" required /></label><br/>
+    <label>Estado: <input type="text" name="state" required /></label><br/>
+    <label>Cidade: <input type="text" name="city" required /></label><br/>
+    <label>Bairro: <input type="text" name="neighborhood" required /></label><br/>
+    <label>Rua: <input type="text" name="street" required /></label><br/>
+    <label>CEP: <input type="text" name="postalCode" /></label><br/>
+    <button type="submit">Salvar</button>
+  </form>
+  <div id="result"></div>
+  <script>
+    document.getElementById('addressForm').addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const formData = new FormData(this);
+      const payload = Object.fromEntries(formData.entries());
+      try {
+        const response = await fetch('/address/persist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = await response.json();
+        document.getElementById('result').textContent = data.message || 'Erro ao cadastrar';
+      } catch (err) {
+        document.getElementById('result').textContent = 'Erro ao conectar com o servidor';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Páginas de Cadastro</title>
+</head>
+<body>
+  <h1>Páginas de Cadastro</h1>
+  <ul>
+    <li><a href="/public/address.html">Cadastrar Endereço</a></li>
+    <li><a href="/public/institution.html">Cadastrar Instituição</a></li>
+  </ul>
+</body>
+</html>

--- a/public/institution.html
+++ b/public/institution.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cadastro de Instituição</title>
+</head>
+<body>
+  <h1>Cadastro de Instituição</h1>
+  <form id="institutionForm">
+    <label>Nome: <input type="text" name="name" required /></label><br/>
+    <label>Documento: <input type="text" name="document_number" required /></label><br/>
+    <label>ID do Endereço: <input type="number" name="address_id" required /></label><br/>
+    <button type="submit">Salvar</button>
+  </form>
+  <div id="result"></div>
+  <script>
+    document.getElementById('institutionForm').addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const formData = new FormData(this);
+      const payload = Object.fromEntries(formData.entries());
+      try {
+        const response = await fetch('/institution/persist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = await response.json();
+        document.getElementById('result').textContent = data.message || 'Erro ao cadastrar';
+      } catch (err) {
+        document.getElementById('result').textContent = 'Erro ao conectar com o servidor';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add address registration form
- add institution registration form
- link forms from an index page and adjust gitignore

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689650f241a883259c6ba3adc736390f