### PR TITLE
feat: add suppliers and products test database

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,14 @@
   * ```
     npm run dev
     ```
+
+## Banco de teste
+
+O arquivo `test_db.sql` cria tabelas de fornecedores (`supplier`) e produtos (`product`) com alguns dados de exemplo para testes.
+
+Para carregar esse banco no PostgreSQL local utilize:
+
+```
+psql -U postgres -d arni-api -f test_db.sql
+```
     

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -1,0 +1,133 @@
+import ProductModel from '../models/ProductModel';
+
+const get = async (req, res) => {
+  try {
+    const id = req.params.id ? req.params.id.toString().replace(/\D/g, '') : null;
+
+    if (!id) {
+      const response = await ProductModel.findAll({
+        order: [['id', 'asc']],
+      });
+      return res.status(200).send({
+        type: 'success',
+        message: 'Registros carregados com sucesso',
+        data: response,
+      });
+    }
+
+    const response = await ProductModel.findOne({ where: { id } });
+
+    if (!response) {
+      return res.status(200).send({
+        type: 'error',
+        message: `Nenhum registro com id ${id}`,
+        data: [],
+      });
+    }
+
+    return res.status(200).send({
+      type: 'success',
+      message: 'Registro carregado com sucesso',
+      data: response,
+    });
+  } catch (error) {
+    return res.status(200).send({
+      type: 'error',
+      message: 'Ops! Ocorreu um erro',
+      error: error.message,
+    });
+  }
+};
+
+const create = async (dados, res) => {
+  const { name, price, supplierId } = dados;
+
+  const response = await ProductModel.create({ name, price, supplierId });
+
+  return res.status(200).send({
+    type: 'success',
+    message: 'Cadastro realizado com sucesso',
+    data: response,
+  });
+};
+
+const update = async (id, dados, res) => {
+  const response = await ProductModel.findOne({ where: { id } });
+
+  if (!response) {
+    return res.status(200).send({
+      type: 'error',
+      message: `Nenhum registro com id ${id} para atualizar`,
+      data: [],
+    });
+  }
+
+  Object.keys(dados).forEach((field) => response[field] = dados[field]);
+
+  await response.save();
+  return res.status(200).send({
+    type: 'success',
+    message: `Registro id ${id} atualizado com sucesso`,
+    data: response,
+  });
+};
+
+const persist = async (req, res) => {
+  try {
+    const id = req.params.id ? req.params.id.toString().replace(/\D/g, '') : null;
+
+    if (!id) {
+      return await create(req.body, res);
+    }
+
+    return await update(id, req.body, res);
+  } catch (error) {
+    return res.status(200).send({
+      type: 'error',
+      message: 'Ops! Ocorreu um erro',
+      error,
+    });
+  }
+};
+
+const destroy = async (req, res) => {
+  try {
+    const id = req.body.id ? req.body.id.toString().replace(/\D/g, '') : null;
+    if (!id) {
+      return res.status(200).send({
+        type: 'error',
+        message: 'Informe um id para deletar o registro',
+        data: [],
+      });
+    }
+
+    const response = await ProductModel.findOne({ where: { id } });
+
+    if (!response) {
+      return res.status(200).send({
+        type: 'error',
+        message: `Nenhum registro com id ${id} para deletar`,
+        data: [],
+      });
+    }
+
+    await response.destroy();
+    return res.status(200).send({
+      type: 'success',
+      message: `Registro id ${id} deletado com sucesso`,
+      data: [],
+    });
+  } catch (error) {
+    return res.status(200).send({
+      type: 'error',
+      message: 'Ops! Ocorreu um erro',
+      error: error.message,
+    });
+  }
+};
+
+export default {
+  get,
+  persist,
+  destroy,
+};

--- a/src/controllers/supplierController.js
+++ b/src/controllers/supplierController.js
@@ -1,0 +1,133 @@
+import SupplierModel from '../models/SupplierModel';
+
+const get = async (req, res) => {
+  try {
+    const id = req.params.id ? req.params.id.toString().replace(/\D/g, '') : null;
+
+    if (!id) {
+      const response = await SupplierModel.findAll({
+        order: [['id', 'asc']],
+      });
+      return res.status(200).send({
+        type: 'success',
+        message: 'Registros carregados com sucesso',
+        data: response,
+      });
+    }
+
+    const response = await SupplierModel.findOne({ where: { id } });
+
+    if (!response) {
+      return res.status(200).send({
+        type: 'error',
+        message: `Nenhum registro com id ${id}`,
+        data: [],
+      });
+    }
+
+    return res.status(200).send({
+      type: 'success',
+      message: 'Registro carregado com sucesso',
+      data: response,
+    });
+  } catch (error) {
+    return res.status(200).send({
+      type: 'error',
+      message: 'Ops! Ocorreu um erro',
+      error: error.message,
+    });
+  }
+};
+
+const create = async (dados, res) => {
+  const { name, contactEmail } = dados;
+
+  const response = await SupplierModel.create({ name, contactEmail });
+
+  return res.status(200).send({
+    type: 'success',
+    message: 'Cadastro realizado com sucesso',
+    data: response,
+  });
+};
+
+const update = async (id, dados, res) => {
+  const response = await SupplierModel.findOne({ where: { id } });
+
+  if (!response) {
+    return res.status(200).send({
+      type: 'error',
+      message: `Nenhum registro com id ${id} para atualizar`,
+      data: [],
+    });
+  }
+
+  Object.keys(dados).forEach((field) => response[field] = dados[field]);
+
+  await response.save();
+  return res.status(200).send({
+    type: 'success',
+    message: `Registro id ${id} atualizado com sucesso`,
+    data: response,
+  });
+};
+
+const persist = async (req, res) => {
+  try {
+    const id = req.params.id ? req.params.id.toString().replace(/\D/g, '') : null;
+
+    if (!id) {
+      return await create(req.body, res);
+    }
+
+    return await update(id, req.body, res);
+  } catch (error) {
+    return res.status(200).send({
+      type: 'error',
+      message: 'Ops! Ocorreu um erro',
+      error,
+    });
+  }
+};
+
+const destroy = async (req, res) => {
+  try {
+    const id = req.body.id ? req.body.id.toString().replace(/\D/g, '') : null;
+    if (!id) {
+      return res.status(200).send({
+        type: 'error',
+        message: 'Informe um id para deletar o registro',
+        data: [],
+      });
+    }
+
+    const response = await SupplierModel.findOne({ where: { id } });
+
+    if (!response) {
+      return res.status(200).send({
+        type: 'error',
+        message: `Nenhum registro com id ${id} para deletar`,
+        data: [],
+      });
+    }
+
+    await response.destroy();
+    return res.status(200).send({
+      type: 'success',
+      message: `Registro id ${id} deletado com sucesso`,
+      data: [],
+    });
+  } catch (error) {
+    return res.status(200).send({
+      type: 'error',
+      message: 'Ops! Ocorreu um erro',
+      error: error.message,
+    });
+  }
+};
+
+export default {
+  get,
+  persist,
+  destroy,
+};

--- a/src/models/ProductModel.js
+++ b/src/models/ProductModel.js
@@ -1,0 +1,40 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../config/config';
+import Supplier from './SupplierModel';
+
+const Product = sequelize.define(
+  'product',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    price: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    supplierId: {
+      field: 'supplier_id',
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    freezeTableName: true,
+    timestamps: false,
+  },
+);
+
+Product.belongsTo(Supplier, {
+  as: 'Supplier',
+  foreignKey: { name: 'supplier_id', allowNull: false },
+  onUpdate: 'NO ACTION',
+  onDelete: 'NO ACTION',
+});
+
+export default Product;

--- a/src/models/SupplierModel.js
+++ b/src/models/SupplierModel.js
@@ -1,0 +1,28 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../config/config';
+
+const Supplier = sequelize.define(
+  'supplier',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    contactEmail: {
+      field: 'contact_email',
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+  },
+  {
+    freezeTableName: true,
+    timestamps: false,
+  },
+);
+
+export default Supplier;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,9 +1,13 @@
 import adressRoute from './addressRoute';
 import institutionRoute from './institutionRoute';
+import supplierRoute from './supplierRoute';
+import productRoute from './productRoute';
 
 function Routes(app) {
-  institutionRoute(app)
+  institutionRoute(app);
   adressRoute(app);
+  supplierRoute(app);
+  productRoute(app);
 }
 
 export default Routes;

--- a/src/routes/productRoute.js
+++ b/src/routes/productRoute.js
@@ -1,0 +1,9 @@
+import controller from '../controllers/productController';
+
+export default (app) => {
+  app.post('/product/persist', controller.persist);
+  app.post('/product/persist/:id', controller.persist);
+  app.post('/product/destroy', controller.destroy);
+  app.get('/product', controller.get);
+  app.get('/product/:id', controller.get);
+};

--- a/src/routes/supplierRoute.js
+++ b/src/routes/supplierRoute.js
@@ -1,0 +1,9 @@
+import controller from '../controllers/supplierController';
+
+export default (app) => {
+  app.post('/supplier/persist', controller.persist);
+  app.post('/supplier/persist/:id', controller.persist);
+  app.post('/supplier/destroy', controller.destroy);
+  app.get('/supplier', controller.get);
+  app.get('/supplier/:id', controller.get);
+};

--- a/test_db.sql
+++ b/test_db.sql
@@ -1,0 +1,23 @@
+-- Test database for store with suppliers and products
+CREATE TABLE supplier (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  contact_email VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE product (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  price NUMERIC(10,2) NOT NULL,
+  supplier_id INTEGER NOT NULL REFERENCES supplier(id)
+);
+
+INSERT INTO supplier (name, contact_email) VALUES
+  ('ABC Distributors', 'contact@abc.com'),
+  ('Global Supplies', 'sales@globalsupplies.com');
+
+INSERT INTO product (name, price, supplier_id) VALUES
+  ('Notebook', 3500.00, 1),
+  ('Mouse Wireless', 80.00, 1),
+  ('Monitor 24"', 900.00, 2),
+  ('Keyboard Mechanical', 450.00, 2);


### PR DESCRIPTION
## Summary
- add supplier and product models, controllers, and routes
- provide test SQL script with sample suppliers and products
- document how to load the test database

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68965107c2c883259136cf6186d3efa4