### PR TITLE
feat: add basic views for address and institution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
+    "ejs": "^3.1.10",
     "esm": "^3.2.25",
     "express": "^4.18.1",
     "express-fileupload": "^1.4.0",

--- a/src/controllers/addressController.js
+++ b/src/controllers/addressController.js
@@ -39,6 +39,24 @@ const get = async (req, res) => {
   }
 };
 
+const listView = async (req, res) => {
+  const addresses = await AdressModel.findAll({
+    order: [['id', 'asc']],
+  });
+  return res.render('address/index', { addresses });
+};
+
+const createView = (req, res) => res.render('address/form', { address: null });
+
+const editView = async (req, res) => {
+  const id = req.params.id ? req.params.id.toString().replace(/\D/g, '') : null;
+  const address = await AdressModel.findOne({ where: { id } });
+  if (!address) {
+    return res.status(404).send('Address not found');
+  }
+  return res.render('address/form', { address });
+};
+
 const create = async (dados, res) => {
   const {
     country, state, city, neighborhood, street, postalCode,
@@ -139,4 +157,7 @@ export default {
   get,
   persist,
   destroy,
+  listView,
+  createView,
+  editView,
 };

--- a/src/controllers/institutionController.js
+++ b/src/controllers/institutionController.js
@@ -40,6 +40,24 @@ const get = async (req, res) => {
   }
 };
 
+const listView = async (req, res) => {
+  const institutions = await institutionModel.findAll({
+    order: [['id', 'asc']],
+  });
+  return res.render('institution/index', { institutions });
+};
+
+const createView = (req, res) => res.render('institution/form', { institution: null });
+
+const editView = async (req, res) => {
+  const id = req.params.id ? req.params.id.toString().replace(/\D/g, '') : null;
+  const institution = await institutionModel.findOne({ where: { id } });
+  if (!institution) {
+    return res.status(404).send('Institution not found');
+  }
+  return res.render('institution/form', { institution });
+};
+
 const create = async (dados, res) => {
   const { name,document_number, address_id } = dados;
 
@@ -131,4 +149,7 @@ export default {
   get,
   persist,
   destroy,
+  listView,
+  createView,
+  editView,
 };

--- a/src/routes/addressRoute.js
+++ b/src/routes/addressRoute.js
@@ -6,4 +6,7 @@ export default (app) => {
   app.post('/address/destroy', controller.destroy);
   app.get('/address', controller.get);
   app.get('/address/:id', controller.get);
+  app.get('/address/view', controller.listView);
+  app.get('/address/view/create', controller.createView);
+  app.get('/address/view/edit/:id', controller.editView);
 };

--- a/src/routes/institutionRoute.js
+++ b/src/routes/institutionRoute.js
@@ -6,4 +6,7 @@ export default (app) => {
   app.post('/institution/destroy', controller.destroy);
   app.get('/institution', controller.get);
   app.get('/institution/:id', controller.get);
+  app.get('/institution/view', controller.listView);
+  app.get('/institution/view/create', controller.createView);
+  app.get('/institution/view/edit/:id', controller.editView);
 };

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,8 @@ import fileupload from 'express-fileupload';
 import routes from './routes';
 
 const app = express();
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
 
 const accessLogStream = fs.createWriteStream(
   path.join(__dirname, '../access.log'),

--- a/src/views/address/form.ejs
+++ b/src/views/address/form.ejs
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= address ? 'Edit' : 'Create' %> Address</title>
+</head>
+<body>
+  <h1><%= address ? 'Edit' : 'Create' %> Address</h1>
+  <form method="post" action="<%= address ? '/address/persist/' + address.id : '/address/persist' %>">
+    <div>
+      <label>Country:</label>
+      <input type="text" name="country" value="<%= address ? address.country : '' %>" required>
+    </div>
+    <div>
+      <label>State:</label>
+      <input type="text" name="state" value="<%= address ? address.state : '' %>" required>
+    </div>
+    <div>
+      <label>City:</label>
+      <input type="text" name="city" value="<%= address ? address.city : '' %>" required>
+    </div>
+    <div>
+      <label>Neighborhood:</label>
+      <input type="text" name="neighborhood" value="<%= address ? address.neighborhood : '' %>" required>
+    </div>
+    <div>
+      <label>Street:</label>
+      <input type="text" name="street" value="<%= address ? address.street : '' %>" required>
+    </div>
+    <div>
+      <label>Postal Code:</label>
+      <input type="text" name="postalCode" value="<%= address ? address.postalCode : '' %>">
+    </div>
+    <button type="submit">Save</button>
+  </form>
+  <a href="/address/view">Back</a>
+</body>
+</html>

--- a/src/views/address/index.ejs
+++ b/src/views/address/index.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Addresses</title>
+</head>
+<body>
+  <h1>Addresses</h1>
+  <a href="/address/view/create">Create Address</a>
+  <ul>
+    <% addresses.forEach(function(addr) { %>
+      <li>
+        <%= addr.street %>, <%= addr.city %> - 
+        <a href="/address/view/edit/<%= addr.id %>">Edit</a>
+        <form method="post" action="/address/destroy" style="display:inline">
+          <input type="hidden" name="id" value="<%= addr.id %>">
+          <button type="submit">Delete</button>
+        </form>
+      </li>
+    <% }); %>
+  </ul>
+</body>
+</html>

--- a/src/views/institution/form.ejs
+++ b/src/views/institution/form.ejs
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= institution ? 'Edit' : 'Create' %> Institution</title>
+</head>
+<body>
+  <h1><%= institution ? 'Edit' : 'Create' %> Institution</h1>
+  <form method="post" action="<%= institution ? '/institution/persist/' + institution.id : '/institution/persist' %>">
+    <div>
+      <label>Name:</label>
+      <input type="text" name="name" value="<%= institution ? institution.name : '' %>" required>
+    </div>
+    <div>
+      <label>Document Number:</label>
+      <input type="text" name="document_number" value="<%= institution ? institution.document_number : '' %>" required>
+    </div>
+    <div>
+      <label>Address ID:</label>
+      <input type="number" name="address_id" value="<%= institution ? institution.address_id : '' %>" required>
+    </div>
+    <button type="submit">Save</button>
+  </form>
+  <a href="/institution/view">Back</a>
+</body>
+</html>

--- a/src/views/institution/index.ejs
+++ b/src/views/institution/index.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Institutions</title>
+</head>
+<body>
+  <h1>Institutions</h1>
+  <a href="/institution/view/create">Create Institution</a>
+  <ul>
+    <% institutions.forEach(function(inst) { %>
+      <li>
+        <%= inst.name %> - 
+        <a href="/institution/view/edit/<%= inst.id %>">Edit</a>
+        <form method="post" action="/institution/destroy" style="display:inline">
+          <input type="hidden" name="id" value="<%= inst.id %>">
+          <button type="submit">Delete</button>
+        </form>
+      </li>
+    <% }); %>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- configure Express to render EJS views
- add CRUD view handlers for Address and Institution
- create simple EJS templates for listing, creating and editing records

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896511ce5dc8325899af6825f0426a7